### PR TITLE
Version 1.12.8.0-release `<Archival>`

### DIFF
--- a/GameData/NecroBones/ModularRocketSystems/Patches/MRS_DeadlyReentry.cfg
+++ b/GameData/NecroBones/ModularRocketSystems/Patches/MRS_DeadlyReentry.cfg
@@ -6,6 +6,7 @@
 {
 	@maxTemp = 1523.15
 	@emissiveConstant = 0.6
+
 	MODULE
 	{
 		name = ModuleAeroReentry
@@ -18,6 +19,7 @@
 {
 	@maxTemp = 1523.15
 	@emissiveConstant = 0.6
+
 	MODULE
 	{
 		name = ModuleAeroReentry
@@ -29,6 +31,7 @@
 @PART[NB*tank*|NB*Tank*|NBjumboThreeQ|NBhalfJumbo|NBmonoprop3m|NBwhiteJumbo|NBminiOrangeR]:FOR[ModRocketSys]:NEEDS[DeadlyReentry]
 {
 	@maxTemp = 1073.15
+
 
 	MODULE
 	{

--- a/GameData/NecroBones/ModularRocketSystems/Patches/MRS_HotRockets.cfg
+++ b/GameData/NecroBones/ModularRocketSystems/Patches/MRS_HotRockets.cfg
@@ -1,12 +1,12 @@
 @PART[NB2mNuclearEngine]:NEEDS[HotRockets] // "Quad-Nuke" 2.5m Atomic Rocket
 {
-    !fx_exhaustFlame_blue {}
-    !fx_exhaustLight_blue {}
-    !fx_smokeTrail_light {}
-    !sound_vent_medium {}
-    !sound_rocket_hard {}
-    !sound_vent_soft {}
-    !sound_explosion_low {}
+    !fx_exhaustFlame_blue {} {}
+    !fx_exhaustLight_blue {} {}
+    !fx_smokeTrail_light {} {}
+    !sound_vent_medium {} {}
+    !sound_rocket_hard {} {}
+    !sound_vent_soft {} {}
+    !sound_explosion_low {} {}
     EFFECTS
     {
         powerflame
@@ -83,7 +83,7 @@
         //engineID = rocketengine
         runningEffectName = powersmoke
         directThrottleEffectName = powerflame
-	!fxOffset {}
+	!fxOffset {} {}
 	
     }
     @MODULE[ModuleEngineConfigs]
@@ -200,18 +200,18 @@ MODEL_MULTI_PARTICLE_PERSIST
 
 @PART[NBjetBasic0m]:NEEDS[HotRockets] // Mini Basic Jet Engine
 {
-    !fx_exhaustLight_blue {}
-    !fx_smokeTrail_light {}
-    !fx_exhaustSparks_flameout {}
-    !sound_vent_medium {}
-    !sound_jet_low {}
-    !sound_jet_deep {}
-    !sound_vent_soft {}
-    !sound_explosion_low {}
+    !fx_exhaustLight_blue {} {}
+    !fx_smokeTrail_light {} {}
+    !fx_exhaustSparks_flameout {} {}
+    !sound_vent_medium {} {}
+    !sound_jet_low {} {}
+    !sound_jet_deep {} {}
+    !sound_vent_soft {} {}
+    !sound_explosion_low {} {}
     @EFFECTS
     {
-	!running_thrust {}
-	!running_turbine {}
+	!running_thrust {} {}
+	!running_turbine {} {}
         powerflame
         {
             MODEL_MULTI_PARTICLE_PERSIST
@@ -325,9 +325,9 @@ MODEL_MULTI_PARTICLE_PERSIST
     {
         runningEffectName = powersmoke
         directThrottleEffectName = powerflame
-	!spoolEffectName  {}
-	!powerEffectName  {}
-	!fxOffset {}
+	!spoolEffectName  {} {}
+	!powerEffectName  {} {}
+	!fxOffset {} {}
     }
     @MODULE[ModuleEngineConfigs]
     {
@@ -340,18 +340,18 @@ MODEL_MULTI_PARTICLE_PERSIST
 
 @PART[NBjetTurbo0m]:NEEDS[HotRockets] //Mini TurboJet
 {
-    !fx_exhaustLight_yellow {}
-    !fx_smokeTrail_light {}
-    !fx_exhaustSparks_flameout {}
-    !sound_vent_medium {}
-    !sound_jet_low {}
-    !sound_jet_deep {}
-    !sound_vent_soft {}
-    !sound_explosion_low {}
+    !fx_exhaustLight_yellow {} {}
+    !fx_smokeTrail_light {} {}
+    !fx_exhaustSparks_flameout {} {}
+    !sound_vent_medium {} {}
+    !sound_jet_low {} {}
+    !sound_jet_deep {} {}
+    !sound_vent_soft {} {}
+    !sound_explosion_low {} {}
     @EFFECTS
     {
-	!running_thrust {}
-	!running_turbine {}
+	!running_thrust {} {}
+	!running_turbine {} {}
         powerflame
         {
             MODEL_MULTI_PARTICLE_PERSIST
@@ -464,9 +464,9 @@ MODEL_MULTI_PARTICLE_PERSIST
     {
         runningEffectName = powersmoke
         directThrottleEffectName = powerflame
-	!spoolEffectName  {}
-	!powerEffectName  {}
-	!fxOffset {}
+	!spoolEffectName  {} {}
+	!powerEffectName  {} {}
+	!fxOffset {} {}
     }
     @MODULE[ModuleEngineConfigs]
     {
@@ -478,14 +478,14 @@ MODEL_MULTI_PARTICLE_PERSIST
 
 @PART[NB3mTerrierEngine]:NEEDS[HotRockets] // "Terrier" 3.75m poodle-like engine
 {
-    !fx_exhaustFlame_blue {}
-    !fx_exhaustLight_blue {}
-    !fx_smokeTrail_light {}
-    //!fx_exhaustSparks_flameout {}
-    !sound_vent_medium {}
-    !sound_rocket_hard {}
-    !sound_vent_soft {}
-    !sound_explosion_low {}
+    !fx_exhaustFlame_blue {} {}
+    !fx_exhaustLight_blue {} {}
+    !fx_smokeTrail_light {} {}
+    //!fx_exhaustSparks_flameout {} {}
+    !sound_vent_medium {} {}
+    !sound_rocket_hard {} {}
+    !sound_vent_soft {} {}
+    !sound_explosion_low {} {}
     EFFECTS
     {
         powerflame
@@ -562,7 +562,7 @@ MODEL_MULTI_PARTICLE_PERSIST
         //engineID = rocketengine
         runningEffectName = powersmoke
         directThrottleEffectName = powerflame
-	!fxOffset {}
+	!fxOffset {} {}
 	
     }
     @MODULE[ModuleEngineConfigs]
@@ -573,14 +573,14 @@ MODEL_MULTI_PARTICLE_PERSIST
 
 @PART[NB0mLFOengine1]:NEEDS[HotRockets] // 0.625m LFO engine
 {
-    !fx_exhaustFlame_blue {}
-    !fx_exhaustLight_blue {}
-    !fx_smokeTrail_light {}
-    !fx_exhaustSparks_flameout {}
-    !sound_vent_medium {}
-    !sound_rocket_hard {}
-    !sound_vent_soft {}
-    !sound_explosion_low {}
+    !fx_exhaustFlame_blue {} {}
+    !fx_exhaustLight_blue {} {}
+    !fx_smokeTrail_light {} {}
+    !fx_exhaustSparks_flameout {} {}
+    !sound_vent_medium {} {}
+    !sound_rocket_hard {} {}
+    !sound_vent_soft {} {}
+    !sound_explosion_low {} {}
     EFFECTS
     {
         powerflame
@@ -709,7 +709,7 @@ MODEL_MULTI_PARTICLE_PERSIST
         //engineID = rocketengine
         runningEffectName = powersmoke
         directThrottleEffectName = powerflame
-	!fxOffset {}
+	!fxOffset {} {}
 	
     }
     @MODULE[ModuleEngineConfigs]

--- a/GameData/NecroBones/ModularRocketSystems/Patches/MRS_HotRockets.cfg
+++ b/GameData/NecroBones/ModularRocketSystems/Patches/MRS_HotRockets.cfg
@@ -1,12 +1,12 @@
 @PART[NB2mNuclearEngine]:NEEDS[HotRockets] // "Quad-Nuke" 2.5m Atomic Rocket
 {
-    !fx_exhaustFlame_blue {} {}
-    !fx_exhaustLight_blue {} {}
-    !fx_smokeTrail_light {} {}
-    !sound_vent_medium {} {}
-    !sound_rocket_hard {} {}
-    !sound_vent_soft {} {}
-    !sound_explosion_low {} {}
+    !fx_exhaustFlame_blue {}
+    !fx_exhaustLight_blue {}
+    !fx_smokeTrail_light {}
+    !sound_vent_medium {}
+    !sound_rocket_hard {}
+    !sound_vent_soft {}
+    !sound_explosion_low {}
     EFFECTS
     {
         powerflame
@@ -83,7 +83,7 @@
         //engineID = rocketengine
         runningEffectName = powersmoke
         directThrottleEffectName = powerflame
-	!fxOffset {} {}
+	!fxOffset {}
 	
     }
     @MODULE[ModuleEngineConfigs]
@@ -168,7 +168,7 @@ MODEL_MULTI_PARTICLE_PERSIST
 	// ***************
 
 
-	angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45° 	
+	angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45ï¿½ 	
 	angle = 45.0 1.0
 	angle = 50.0 1.0
 	distance = 0.0 1.0 // Display if the distance to camera is higher than 110
@@ -200,18 +200,18 @@ MODEL_MULTI_PARTICLE_PERSIST
 
 @PART[NBjetBasic0m]:NEEDS[HotRockets] // Mini Basic Jet Engine
 {
-    !fx_exhaustLight_blue {} {}
-    !fx_smokeTrail_light {} {}
-    !fx_exhaustSparks_flameout {} {}
-    !sound_vent_medium {} {}
-    !sound_jet_low {} {}
-    !sound_jet_deep {} {}
-    !sound_vent_soft {} {}
-    !sound_explosion_low {} {}
+    !fx_exhaustLight_blue {}
+    !fx_smokeTrail_light {}
+    !fx_exhaustSparks_flameout {}
+    !sound_vent_medium {}
+    !sound_jet_low {}
+    !sound_jet_deep {}
+    !sound_vent_soft {}
+    !sound_explosion_low {}
     @EFFECTS
     {
-	!running_thrust {} {}
-	!running_turbine {} {}
+	!running_thrust {}
+	!running_turbine {}
         powerflame
         {
             MODEL_MULTI_PARTICLE_PERSIST
@@ -299,7 +299,7 @@ MODEL_MULTI_PARTICLE_PERSIST
 	// ***************
 
 
-	angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45° 	
+	angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45ï¿½ 	
 	angle = 45.0 1.0
 	angle = 50.0 1.0
 	distance = 0.0 1.0 // Display if the distance to camera is higher than 110
@@ -325,9 +325,9 @@ MODEL_MULTI_PARTICLE_PERSIST
     {
         runningEffectName = powersmoke
         directThrottleEffectName = powerflame
-	!spoolEffectName  {} {}
-	!powerEffectName  {} {}
-	!fxOffset {} {}
+	!spoolEffectName  {}
+	!powerEffectName  {}
+	!fxOffset {}
     }
     @MODULE[ModuleEngineConfigs]
     {
@@ -340,18 +340,18 @@ MODEL_MULTI_PARTICLE_PERSIST
 
 @PART[NBjetTurbo0m]:NEEDS[HotRockets] //Mini TurboJet
 {
-    !fx_exhaustLight_yellow {} {}
-    !fx_smokeTrail_light {} {}
-    !fx_exhaustSparks_flameout {} {}
-    !sound_vent_medium {} {}
-    !sound_jet_low {} {}
-    !sound_jet_deep {} {}
-    !sound_vent_soft {} {}
-    !sound_explosion_low {} {}
+    !fx_exhaustLight_yellow {}
+    !fx_smokeTrail_light {}
+    !fx_exhaustSparks_flameout {}
+    !sound_vent_medium {}
+    !sound_jet_low {}
+    !sound_jet_deep {}
+    !sound_vent_soft {}
+    !sound_explosion_low {}
     @EFFECTS
     {
-	!running_thrust {} {}
-	!running_turbine {} {}
+	!running_thrust {}
+	!running_turbine {}
         powerflame
         {
             MODEL_MULTI_PARTICLE_PERSIST
@@ -439,7 +439,7 @@ MODEL_MULTI_PARTICLE_PERSIST
 	// ***************
 
 
-	angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45° 	
+	angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45ï¿½ 	
 	angle = 45.0 1.0
 	angle = 50.0 1.0
 	distance = 0.0 1.0 // Display if the distance to camera is higher than 110
@@ -464,9 +464,9 @@ MODEL_MULTI_PARTICLE_PERSIST
     {
         runningEffectName = powersmoke
         directThrottleEffectName = powerflame
-	!spoolEffectName  {} {}
-	!powerEffectName  {} {}
-	!fxOffset {} {}
+	!spoolEffectName  {}
+	!powerEffectName  {}
+	!fxOffset {}
     }
     @MODULE[ModuleEngineConfigs]
     {
@@ -478,14 +478,14 @@ MODEL_MULTI_PARTICLE_PERSIST
 
 @PART[NB3mTerrierEngine]:NEEDS[HotRockets] // "Terrier" 3.75m poodle-like engine
 {
-    !fx_exhaustFlame_blue {} {}
-    !fx_exhaustLight_blue {} {}
-    !fx_smokeTrail_light {} {}
-    //!fx_exhaustSparks_flameout {} {}
-    !sound_vent_medium {} {}
-    !sound_rocket_hard {} {}
-    !sound_vent_soft {} {}
-    !sound_explosion_low {} {}
+    !fx_exhaustFlame_blue {}
+    !fx_exhaustLight_blue {}
+    !fx_smokeTrail_light {}
+    //!fx_exhaustSparks_flameout {}
+    !sound_vent_medium {}
+    !sound_rocket_hard {}
+    !sound_vent_soft {}
+    !sound_explosion_low {}
     EFFECTS
     {
         powerflame
@@ -562,7 +562,7 @@ MODEL_MULTI_PARTICLE_PERSIST
         //engineID = rocketengine
         runningEffectName = powersmoke
         directThrottleEffectName = powerflame
-	!fxOffset {} {}
+	!fxOffset {}
 	
     }
     @MODULE[ModuleEngineConfigs]
@@ -573,14 +573,14 @@ MODEL_MULTI_PARTICLE_PERSIST
 
 @PART[NB0mLFOengine1]:NEEDS[HotRockets] // 0.625m LFO engine
 {
-    !fx_exhaustFlame_blue {} {}
-    !fx_exhaustLight_blue {} {}
-    !fx_smokeTrail_light {} {}
-    !fx_exhaustSparks_flameout {} {}
-    !sound_vent_medium {} {}
-    !sound_rocket_hard {} {}
-    !sound_vent_soft {} {}
-    !sound_explosion_low {} {}
+    !fx_exhaustFlame_blue {}
+    !fx_exhaustLight_blue {}
+    !fx_smokeTrail_light {}
+    !fx_exhaustSparks_flameout {}
+    !sound_vent_medium {}
+    !sound_rocket_hard {}
+    !sound_vent_soft {}
+    !sound_explosion_low {}
     EFFECTS
     {
         powerflame
@@ -649,7 +649,7 @@ MODEL_MULTI_PARTICLE_PERSIST
 	// ***************
 
 
-	angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45° 	
+	angle = 0.0 1.0 // Display if the angle between the emitter transform and camera is lower than 45ï¿½ 	
 	angle = 45.0 1.0
 	angle = 50.0 1.0
 	distance = 0.0 1.0 // Display if the distance to camera is higher than 110
@@ -709,7 +709,7 @@ MODEL_MULTI_PARTICLE_PERSIST
         //engineID = rocketengine
         runningEffectName = powersmoke
         directThrottleEffectName = powerflame
-	!fxOffset {} {}
+	!fxOffset {}
 	
     }
     @MODULE[ModuleEngineConfigs]

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ updated:
 TEMPLATE: readme.md v1.7.0.2
 created: 17 Jul 2017
 updated: 10 Feb 2023
-stuff
+
 this file: CC BY-ND 4.0 by zer0Kerbal -->
 
 [![Modular Rocket Systems (MRS)][MOD:shd]][forum] [![KSP version][KSP:shd]][KSP:url]  [![License][LIC:shd]][LIC:url]  

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ updated:
 TEMPLATE: readme.md v1.7.0.2
 created: 17 Jul 2017
 updated: 10 Feb 2023
-
+stuff
 this file: CC BY-ND 4.0 by zer0Kerbal -->
 
 [![Modular Rocket Systems (MRS)][MOD:shd]][forum] [![KSP version][KSP:shd]][KSP:url]  [![License][LIC:shd]][LIC:url]  


### PR DESCRIPTION
# Special note - this is a placeholder PR - 1.12.8.0 was tracking master

## Version 1.12.8.0-release `<Archival>`

* 12 Jul 2016
* Kerbal Space Program 1.1.3

* Tweaks
* Guidance Nose Cone balance tweaks:
  * Cost increased. Research cost increased (was erroneously left at "0").
  * Reaction Wheel torque and electrical usage reduced by 25%.
  * Moved to Flight Control tech node.
* Adjusted some tags, including adding nickname tags for engines.
* Added NearFutureElectrical support for RTG.
* Moved ModuleManager patches to Patches folder.

* Issues
  * updates #7 - Archival Releases
  * closes #61 - 1.12.8.0
  * updates #89 - [BUG] Archival Releases

---

Co-Authored-By: NecroBones <10134364+NecroBones@users.noreply.github.com>